### PR TITLE
Replace signing method with aws4 module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "0.11"
-  - "0.10"
   - "v4"
   - "v5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
+  - "v4"
+  - "v5"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var options = {
   key: '...',
   secret: '...',
   bucket: '...',
-  pathname: '/foo' // optional: prefix all S3 keys with this path
+  prefix: '/foo' // optional: prefix all S3 keys with this path
 };
 var s3 = require('node-s3')(options);
 ```
@@ -44,7 +44,7 @@ Example 1: Upload a body
 s3.put('/some-s3-key', body, callback);
 ```
 
-Example 2: Pipe an incoming http request directly to S3
+Example 2: Pipe an incoming HTTP request directly to S3
 
 ```javascript
 http.createServer(function (req, res) {
@@ -59,9 +59,9 @@ http.createServer(function (req, res) {
 ## API
 
 Common for all functions on the s3 object returned from the node-s3
-constructor is that they take up to 3 arguemnts:
+constructor is that they take up to 3 arguments:
 
-- `key` - The requested S3 key (required). Will be concatinated with the optional pathname given upon initalization
+- `key` - The requested S3 key (required). Will be concatenated with the optional prefix given upon initialization
 - `body` or `options` - Optional body or options hash
 - `callback` - Optional callback called with (err, response, body).
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A simple Amazon S3 node.js integration.
 npm install node-s3
 ```
 
+Supported versions: `v0.11`, `v4`, `v5`
+
 ## Usage
 
 ### Initialization
@@ -36,6 +38,15 @@ var options = {
 var s3 = require('node-s3')(options);
 ```
 
+###### WARNING:
+String parsing will **not** work with period ('.') delimited
+bucket names - buckets must be delimited with something other than
+periods. You can still use the options hash and specify the bucket
+name if your buckets include periods.
+
+
+-----------------
+
 ### Uploading
 
 Example 1: Upload a body
@@ -55,6 +66,8 @@ http.createServer(function (req, res) {
   req.pipe(s3Req);
 }).listen(3000);
 ```
+
+-----------
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -1,86 +1,62 @@
-'use strict';
-
 var curly = require('curly');
-var crypto = require('crypto');
+var aws4 = require('aws4');
 var parseURL = require('url').parse;
 
-var signer = function (key, secret) {
-  if (!key || !secret) throw new Error('S3 key and secret are required!');
-
-  var getStringToSign = function (verb, resource, headers) {
-    var lowerCaseHeaders = {};
-
-    Object.keys(headers).forEach(function (header) {
-      lowerCaseHeaders[header.toLowerCase()] = headers[header];
-    });
-
-    var res = [
-      verb,
-      lowerCaseHeaders['content-md5'] || '',
-      lowerCaseHeaders['content-type'] || '',
-      ''
-    ];
-
-    Object.keys(lowerCaseHeaders)
-      .filter(function (header) {
-        return header.indexOf('x-amz-') === 0;
-      })
-      .sort(function (a, b) {
-        if (a > b) return 1;
-        if (a < b) return -1;
-        return 0;
-      })
-      .forEach(function (header) {
-        res.push(header + ':' + lowerCaseHeaders[header]);
-      });
-
-    res.push(resource);
-
-    return res.join('\n');
-  };
-
-  return function (verb, resource, headers) {
-    headers = headers || {};
-    headers['x-amz-date'] = (new Date()).toUTCString();
-
-    var stringToSign = getStringToSign(verb, resource, headers);
-    var hash = crypto.createHmac('sha1', secret).update(stringToSign).digest('base64');
-
-    headers.authorization = 'AWS ' + key + ':' + hash;
-
-    return headers;
-  };
-};
-
 module.exports = function (options) {
-  var that = {},
-      auth, sign, prefix;
+  var that = {};
+  var host;
+  var auth;
+  var tokens;
 
   options = typeof options === 'string' ? parseURL(options) : options;
+  tokens = options.hostname ? options.hostname.split('.') : [];
 
-  that.pathname = options.pathname || '';
-  that.bucket = options.bucket || options.hostname.split('.')[0];
+  if (!options.region && tokens.length === 5) {
+    options.region = tokens[1];
+  }
 
+  that.prefix = options.prefix || options.pathname || '';
+  that.bucket = options.bucket || tokens[0];
+  that.region = options.region || 'us-east-1';
+
+  host = that.bucket + '.s3.amazonaws.com';
   auth = options.auth ? options.auth.split(':') : [options.key, options.secret];
-  sign = signer(auth[0], auth[1]);
-  prefix = that.bucket + '.s3.amazonaws.com' + that.pathname;
+  auth = {
+    accessKeyId: auth[0],
+    secretAccessKey: auth[1]
+  };
+
+  if (!auth.accessKeyId || !auth.secretAccessKey) {
+    throw 'S3 key and secret are required!';
+  }
 
   ['put', 'post', 'get', 'del', 'head'].forEach(function (method) {
-    var verb = method.replace('del', 'delete').toUpperCase();
+    var verb = method === 'del' ? 'DELETE' : method.toUpperCase();
 
-    that[method] = function request(pathname, options, callback) {
-      if (typeof options === 'function')
-        return request(pathname, null, options);
-      if (typeof options === 'string' || options instanceof Buffer)
-        return request(pathname, { body: options }, callback);
+    that[method] = function request(path, opts, callback) {
+      path = that.prefix + path;
 
-      var signing = '/' + that.bucket + that.pathname + pathname;
+      if (typeof opts === 'function') {
+        return request(path, null, opts);
+      }
+      if (typeof opts === 'string' || opts instanceof Buffer) {
+        return request(path, { body: opts }, callback);
+      }
 
-      options = options || {};
-      options.pool = false;
-      options.headers = sign(verb, signing, options.headers);
+      var awsRequest = curly.use(function (req) { // options
+        req.service = 's3';
+        req.region = that.region;
+        req.host = host;
+        req.method = method;
+        req.path = path;
+        aws4.sign(req, auth);
+        return curly(req);
+      });
 
-      return curly[method](prefix + pathname, options, callback);
+      opts = opts || {};
+      opts.pool = false;
+
+      return awsRequest[verb](host + path, opts, callback);
     };
   });
 

--- a/index.js
+++ b/index.js
@@ -2,56 +2,97 @@ var curly = require('curly');
 var aws4 = require('aws4');
 var parseURL = require('url').parse;
 
+/**
+ * Creates the node-s3 object which includes
+ * information like:
+ * - prefix: the path prefix
+ * - bucket: the bucket to access
+ * - region: the aws region
+ * - auth: the aws creds
+ *
+ * and HTTP methods:
+ * - put
+ * - post
+ * - get
+ * - del
+ * - head
+ *
+ * for making quick requests to amazon S3. The `options` param should be
+ * one of:
+ * - a valid S3 bucket url (if without region, region will default to `us-east-1`)
+ * - an object consisting of:
+ *   - prefix: the path prefix
+ *   - bucket: the s3 bucket
+ *   - region: the s3 region
+ *   - key: the aws user ID key
+ *   - secret: the aws user secret key
+ *
+ * WARNING: string parsing will **not** work with period ('.') delimited
+ * bucket names - buckets must be delimited with something other than
+ * periods. You can still use the options hash and specify the bucket
+ * name if your buckets include periods.
+ * @param  {object} options The options used to init the requests
+ * @return {object}         The initialized object
+ */
 module.exports = function (options) {
   var that = {};
-  var host;
-  var auth;
   var tokens;
+  var temp;
 
+  // Parse string if needed
   options = typeof options === 'string' ? parseURL(options) : options;
   tokens = options.hostname ? options.hostname.split('.') : [];
 
+  // Find region if present
+  // Doesn't work with period delimited buckets
   if (!options.region && tokens.length === 5) {
     options.region = tokens[1];
   }
 
+  // Populate instance info
   that.prefix = options.prefix || options.pathname || '';
   that.bucket = options.bucket || tokens[0];
   that.region = options.region || 'us-east-1';
-
-  host = that.bucket + '.s3.amazonaws.com';
-  auth = options.auth ? options.auth.split(':') : [options.key, options.secret];
-  auth = {
-    accessKeyId: auth[0],
-    secretAccessKey: auth[1]
+  temp = options.auth ?
+    options.auth.split(':') : [options.key, options.secret];
+  that.auth = {
+    accessKeyId: temp[0],
+    secretAccessKey: temp[1]
   };
 
-  if (!auth.accessKeyId || !auth.secretAccessKey) {
+  // Check for AWS creds
+  if (!that.auth.accessKeyId || !that.auth.secretAccessKey) {
     throw 'S3 key and secret are required!';
   }
 
+  /**
+   * Populate HTTP methods
+   */
   ['put', 'post', 'get', 'del', 'head'].forEach(function (method) {
     var verb = method === 'del' ? 'DELETE' : method.toUpperCase();
+    var host = that.bucket + '.s3.amazonaws.com';
 
     that[method] = function request(path, opts, callback) {
-      path = that.prefix + path;
 
-      if (typeof opts === 'function') {
-        return request(path, null, opts);
-      }
-      if (typeof opts === 'string' || opts instanceof Buffer) {
-        return request(path, { body: opts }, callback);
-      }
-
-      var awsRequest = curly.use(function (req) { // options
+      // extend curly
+      var awsRequest = curly.use(function (req) {
         req.service = 's3';
         req.region = that.region;
         req.host = host;
         req.method = method;
-        req.path = path;
-        aws4.sign(req, auth);
+        req.path = that.prefix + path;
+        req.url = req.host + req.path;
+        aws4.sign(req, that.auth);
         return curly(req);
       });
+
+      // Deal with incomplete params
+      if (typeof opts === 'function') {
+        return awsRequest(path, null, opts);
+      }
+      if (typeof opts === 'string' || opts instanceof Buffer) {
+        return awsRequest(path, { body: opts }, callback);
+      }
 
       opts = opts || {};
       opts.pool = false;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git://github.com/pumodo/node-s3.git"
   },
   "dependencies": {
+    "aws4": "^1.2.1",
     "curly": "0.6.x"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var util = require('util');
 var http = require('http');
 var events = require('events');
@@ -8,7 +6,7 @@ var nodes3 = require('./');
 
 test('should correctly parse a string', function (t) {
   var s3 = nodes3('s3://key:secret@bucket.s3.amazonaws.com/prefix');
-  t.equal(s3.pathname, '/prefix', 'have prefix');
+  t.equal(s3.prefix, '/prefix', 'have prefix');
   t.equal(s3.bucket, 'bucket', 'have bucket');
   t.end();
 });
@@ -18,31 +16,31 @@ test('should correctly parse an object', function (t) {
     key: 'key',
     secret: 'secret',
     bucket: 'bucket',
-    pathname: '/prefix'
+    prefix: '/prefix'
   };
   var s3 = nodes3(options);
-  t.equal(s3.pathname, '/prefix', 'have prefix');
+  t.equal(s3.prefix, '/prefix', 'have prefix');
   t.equal(s3.bucket, 'bucket', 'have bucket');
   t.end();
 });
 
 test('should not require a prefix', function (t) {
   var s3 = nodes3('s3://key:secret@bucket.s3.amazonaws.com');
-  t.equal(s3.pathname, '', 'have empty pathname');
+  t.equal(s3.prefix, '', 'have empty prefix');
   var options = {
     key: 'key',
     secret: 'secret',
     bucket: 'bucket'
   };
   s3 = nodes3(options);
-  t.equal(s3.pathname, '', 'have empty pathname');
+  t.equal(s3.prefix, '', 'have empty prefix');
   t.end();
 });
 
 test('should require key/secret', function (t) {
   var fn = function () {
     nodes3('s3://bucket.s3.amazonaws.com');
-  }
+  };
   t.throws(fn, 'S3 key and secret are required!');
   t.end();
 });
@@ -65,7 +63,7 @@ test('should return an EventEmitter', function (t) {
 });
 
 test('should complete a HEAD request', function (t) {
-  var s3 = nodes3('s3://key:secret@bucket.s3.amazonaws.com');
+  var s3 = nodes3('s3://key:secret@bucket.us-east-1.s3.amazonaws.com');
   s3.head('/foo', function (err, res, body) {
     t.equal(err, null, 'have no error');
     t.ok(res instanceof http.IncomingMessage, 'have an IncomingMessage');


### PR DESCRIPTION
The signing method used was not up to date and was not posting
to amazon. This updates the module to use [aws4](https://github.com/mhart/aws4)  to sign
requests.

I tried to stay true to your original tests as much as possible, but the `pathname` -> `prefix` change
warrants a **major** version release.
- Removes the custom signing method and any variables associated.
- Adds logic for parsing region from the URL or options.
- Extends curly to sign all requests passed using `aws4`
- Changes a few tests to match
- Move more info into the returned object
- use that moved info inside of the request methods

Also, there is an issue with the string parsing, where
buckets delimited with '.' will fail, because the bucket
and region cannot be located / built properly. I added
a warning in the code and in the README to publicize this

Side Effects:
- `README` spelling corrections
- Renamed `pathname` to `prefix` for clarity
- Update `travis` to test `v4` and `v5`
- Removes `v.10` from the tests due to an inconsistency with http request
